### PR TITLE
add newrelic deployment tag

### DIFF
--- a/jobs/newrelic-monitor/spec
+++ b/jobs/newrelic-monitor/spec
@@ -13,3 +13,5 @@ templates:
 properties:
   newrelic.license_key:
     description: "Newrelic License Key"
+  newrelic.deployment_tag:
+    description: "The deployment tag that would appear in New Relic."

--- a/jobs/newrelic-monitor/templates/config/nrsysmond.cfg.erb
+++ b/jobs/newrelic-monitor/templates/config/nrsysmond.cfg.erb
@@ -7,4 +7,4 @@ loglevel=info
 
 ssl=true
 
-hostname=<%= name %>-<%= spec.index %>
+hostname=<%= name %>-<%= spec.index %>-<%= properties.newrelic.deployment_tag %>


### PR DESCRIPTION
We wanted to use one set of new relic credentials for multiple deployments and wanted to tag the servers names on new relic with that deployment name. 

Signed-off-by: Tushar Dadlani tdadlani@pivotal.io
