### PR TITLE
Adding ability to overwrite hostnames

### DIFF
--- a/jobs/newrelic-monitor/spec
+++ b/jobs/newrelic-monitor/spec
@@ -18,3 +18,6 @@ properties:
   newrelic.proxy:
     description: "http/https proxy to use to access newrelic saas. see  https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/linux-configuration-new-relic-servers "
     example: "fred:secret@proxy.mydomain.com:8181"
+  newrelic.hostname:
+    description: "Optional: Defines custom hostname for the node instead of using the instance name, followed by index ID and deployment tag.  Leave empty to use the instance name instead."
+    example: "postgres-dev"

--- a/jobs/newrelic-monitor/templates/config/nrsysmond.cfg.erb
+++ b/jobs/newrelic-monitor/templates/config/nrsysmond.cfg.erb
@@ -8,8 +8,11 @@ loglevel=info
 
 ssl=true
 
+<% if properties.newrelic.hostname %>
+hostname=<%= properties.newrelic.hostname %>-<%= spec.index %>-<%= properties.newrelic.deployment_tag %>
+<% else %>
 hostname=<%= name %>-<%= spec.index %>-<%= properties.newrelic.deployment_tag %>
-
+<% end %>
 
 <% if properties.newrelic.deployment_tag %>
 labels="Deployment:<%= properties.newrelic.deployment_tag %>"


### PR DESCRIPTION
TL;DR: This PR enables users to overwrite the "hostname" or instance_name property to differentiate these in Newrelic.

Hostnames are unique identifiers for "nodes" in newrelic, we ran into an edge case where two deployments could have the same instance names and cause newrelic to merge the results from each instance into a single server profile.

@jhunt could you merge this PR?

Thank you!!!
Kit