### PR TITLE
Auto-detect deployment name if not specified

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Improvements
+
+- Autodetect the BOSH deployment name. This allows the newrelic agent
+  to be more generically configured, such that it can run as a BOSH add-on.

--- a/jobs/newrelic-monitor/spec
+++ b/jobs/newrelic-monitor/spec
@@ -14,7 +14,7 @@ properties:
   newrelic.license_key:
     description: "Newrelic License Key"
   newrelic.deployment_tag:
-    description: "The deployment tag that would appear in New Relic."
+    description: "Optional: The deployment tag that would appear in New Relic. Leave empty to pull the deployment name from BOSH"
   newrelic.proxy:
     description: "http/https proxy to use to access newrelic saas. see  https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/linux-configuration-new-relic-servers "
     example: "fred:secret@proxy.mydomain.com:8181"

--- a/jobs/newrelic-monitor/templates/config/nrsysmond.cfg.erb
+++ b/jobs/newrelic-monitor/templates/config/nrsysmond.cfg.erb
@@ -7,16 +7,20 @@ license_key=<%= p("newrelic.license_key") %>
 loglevel=info
 
 ssl=true
+<%
+deployment_name = properties.newrelic.deployment_tag
+if deployment_name.to_s.empty?
+  deployment_name = spec.deployment
+end
+-%>
 
 <% if properties.newrelic.hostname %>
-hostname=<%= properties.newrelic.hostname %>-<%= spec.index %>-<%= properties.newrelic.deployment_tag %>
+hostname=<%= properties.newrelic.hostname %>-<%= spec.index %>-<%= deployment_name %>
 <% else %>
-hostname=<%= name %>-<%= spec.index %>-<%= properties.newrelic.deployment_tag %>
+hostname=<%= name %>-<%= spec.index %>-<%= deployment_name %>
 <% end %>
 
-<% if properties.newrelic.deployment_tag %>
-labels="Deployment:<%= properties.newrelic.deployment_tag %>"
-<% end %>
+labels="Deployment:<%= deployment_name %>"
 
 <% if properties.newrelic.proxy %>
 proxy=<%= properties.newrelic.proxy %>


### PR DESCRIPTION
Allows this release to be used as a BOSH add-on